### PR TITLE
Fix problem with merging of reaction plans

### DIFF
--- a/src/util/vecmap.rs
+++ b/src/util/vecmap.rs
@@ -53,9 +53,9 @@ where
         }
     }
 
-    pub fn entry_from_ref(&mut self, key: KeyRef<K>) -> Entry<K, V> {
-        debug_assert!(self.is_valid_keyref(&key.as_ref()));
-        let KeyRef { min_idx, key } = key;
+    pub fn entry_from_ref(&mut self, key_hint: KeyRef<K>, key: K) -> Entry<K, V> {
+        debug_assert!(self.is_valid_keyref(&key_hint.as_ref()));
+        let KeyRef { min_idx, .. } = key_hint;
         for i in min_idx..self.v.len() {
             match self.v[i].0.cmp(&key) {
                 Ordering::Equal => return Entry::Occupied(OccupiedEntry { map: self, index: i, key }),


### PR DESCRIPTION
Fix #14. The problem was that reactions were being merged in the entry for the wrong level. One reaction was then executed twice on the same time step, at different levels.