### PR TITLE
Simplify access to ports and port banks

### DIFF
--- a/benches/savina_pong.rs
+++ b/benches/savina_pong.rs
@@ -215,11 +215,9 @@ mod reactors {
 
             fn react(&mut self, ctx: &mut ::reactor_rt::ReactionCtx, rid: ::reactor_rt::LocalReactionId) {
                 match rid.raw() {
-                    0 => self.__impl.react_0(
-                        ctx,
-                        self.__receive.as_readable(),
-                        self.__send.as_writable(),
-                    ),
+                    0 => self
+                        .__impl
+                        .react_0(ctx, self.__receive.as_readable(), self.__send.as_writable()),
                     1 => self.__impl.react_1(ctx),
 
                     _ => panic!(
@@ -378,12 +376,8 @@ mod reactors {
 
             fn react(&mut self, ctx: &mut ::reactor_rt::ReactionCtx, rid: ::reactor_rt::LocalReactionId) {
                 match rid.raw() {
-                    0 => self
-                        .__impl
-                        .react_0(ctx, &self.__serve, self.__send.as_writable()),
-                    1 => self
-                        .__impl
-                        .react_1(ctx, self.__receive.as_readable(), &mut self.__serve),
+                    0 => self.__impl.react_0(ctx, &self.__serve, self.__send.as_writable()),
+                    1 => self.__impl.react_1(ctx, self.__receive.as_readable(), &mut self.__serve),
 
                     _ => panic!(
                         "Invalid reaction ID: {} should be < {}",

--- a/benches/savina_pong.rs
+++ b/benches/savina_pong.rs
@@ -217,8 +217,8 @@ mod reactors {
                 match rid.raw() {
                     0 => self.__impl.react_0(
                         ctx,
-                        &::reactor_rt::ReadablePort::new(&self.__receive),
-                        ::reactor_rt::WritablePort::new(&mut self.__send),
+                        &::reactor_rt::ReadablePort::wrap(&self.__receive),
+                        ::reactor_rt::WritablePort::wrap(&mut self.__send),
                     ),
                     1 => self.__impl.react_1(ctx),
 
@@ -380,10 +380,10 @@ mod reactors {
                 match rid.raw() {
                     0 => self
                         .__impl
-                        .react_0(ctx, &self.__serve, ::reactor_rt::WritablePort::new(&mut self.__send)),
+                        .react_0(ctx, &self.__serve, ::reactor_rt::WritablePort::wrap(&mut self.__send)),
                     1 => self
                         .__impl
-                        .react_1(ctx, &::reactor_rt::ReadablePort::new(&self.__receive), &mut self.__serve),
+                        .react_1(ctx, &::reactor_rt::ReadablePort::wrap(&self.__receive), &mut self.__serve),
 
                     _ => panic!(
                         "Invalid reaction ID: {} should be < {}",

--- a/benches/savina_pong.rs
+++ b/benches/savina_pong.rs
@@ -104,8 +104,8 @@ mod reactors {
             fn react_0(
                 &mut self,
                 #[allow(unused)] ctx: &mut ::reactor_rt::ReactionCtx,
-                receive: &::reactor_rt::ReadablePort<u32>,
-                send: &mut ::reactor_rt::WritablePort<u32>,
+                receive: &::reactor_rt::Port<u32>,
+                send: &mut ::reactor_rt::Port<u32>,
             ) {
                 self.count += 1;
                 ctx.set(send, ctx.get(receive).unwrap());
@@ -215,9 +215,7 @@ mod reactors {
 
             fn react(&mut self, ctx: &mut ::reactor_rt::ReactionCtx, rid: ::reactor_rt::LocalReactionId) {
                 match rid.raw() {
-                    0 => self
-                        .__impl
-                        .react_0(ctx, self.__receive.as_readable(), self.__send.as_writable()),
+                    0 => self.__impl.react_0(ctx, &self.__receive, &mut self.__send),
                     1 => self.__impl.react_1(ctx),
 
                     _ => panic!(
@@ -259,7 +257,7 @@ mod reactors {
                 &mut self,
                 #[allow(unused)] ctx: &mut ::reactor_rt::ReactionCtx,
                 #[allow(unused)] serve: &::reactor_rt::LogicalAction<()>,
-                send: &mut ::reactor_rt::WritablePort<u32>,
+                send: &mut ::reactor_rt::Port<u32>,
             ) {
                 ctx.set(send, self.pingsLeft);
                 self.pingsLeft -= 1;
@@ -269,7 +267,7 @@ mod reactors {
             fn react_1(
                 &mut self,
                 #[allow(unused)] ctx: &mut ::reactor_rt::ReactionCtx,
-                _receive: &::reactor_rt::ReadablePort<u32>,
+                _receive: &::reactor_rt::Port<u32>,
                 serve: &mut ::reactor_rt::LogicalAction<()>,
             ) {
                 if self.pingsLeft > 0 {
@@ -376,8 +374,8 @@ mod reactors {
 
             fn react(&mut self, ctx: &mut ::reactor_rt::ReactionCtx, rid: ::reactor_rt::LocalReactionId) {
                 match rid.raw() {
-                    0 => self.__impl.react_0(ctx, &self.__serve, self.__send.as_writable()),
-                    1 => self.__impl.react_1(ctx, self.__receive.as_readable(), &mut self.__serve),
+                    0 => self.__impl.react_0(ctx, &self.__serve, &mut self.__send),
+                    1 => self.__impl.react_1(ctx, &self.__receive, &mut self.__serve),
 
                     _ => panic!(
                         "Invalid reaction ID: {} should be < {}",

--- a/benches/savina_pong.rs
+++ b/benches/savina_pong.rs
@@ -105,7 +105,7 @@ mod reactors {
                 &mut self,
                 #[allow(unused)] ctx: &mut ::reactor_rt::ReactionCtx,
                 receive: &::reactor_rt::ReadablePort<u32>,
-                #[allow(unused_mut)] mut send: ::reactor_rt::WritablePort<u32>,
+                send: &mut ::reactor_rt::WritablePort<u32>,
             ) {
                 self.count += 1;
                 ctx.set(send, ctx.get(receive).unwrap());
@@ -217,8 +217,8 @@ mod reactors {
                 match rid.raw() {
                     0 => self.__impl.react_0(
                         ctx,
-                        &::reactor_rt::ReadablePort::wrap(&self.__receive),
-                        ::reactor_rt::WritablePort::wrap(&mut self.__send),
+                        self.__receive.as_readable(),
+                        self.__send.as_writable(),
                     ),
                     1 => self.__impl.react_1(ctx),
 
@@ -261,7 +261,7 @@ mod reactors {
                 &mut self,
                 #[allow(unused)] ctx: &mut ::reactor_rt::ReactionCtx,
                 #[allow(unused)] serve: &::reactor_rt::LogicalAction<()>,
-                #[allow(unused_mut)] mut send: ::reactor_rt::WritablePort<u32>,
+                send: &mut ::reactor_rt::WritablePort<u32>,
             ) {
                 ctx.set(send, self.pingsLeft);
                 self.pingsLeft -= 1;
@@ -272,7 +272,7 @@ mod reactors {
                 &mut self,
                 #[allow(unused)] ctx: &mut ::reactor_rt::ReactionCtx,
                 _receive: &::reactor_rt::ReadablePort<u32>,
-                #[allow(unused_mut)] mut serve: &mut ::reactor_rt::LogicalAction<()>,
+                serve: &mut ::reactor_rt::LogicalAction<()>,
             ) {
                 if self.pingsLeft > 0 {
                     ctx.schedule(serve, Asap);
@@ -380,10 +380,10 @@ mod reactors {
                 match rid.raw() {
                     0 => self
                         .__impl
-                        .react_0(ctx, &self.__serve, ::reactor_rt::WritablePort::wrap(&mut self.__send)),
+                        .react_0(ctx, &self.__serve, self.__send.as_writable()),
                     1 => self
                         .__impl
-                        .react_1(ctx, &::reactor_rt::ReadablePort::wrap(&self.__receive), &mut self.__serve),
+                        .react_1(ctx, self.__receive.as_readable(), &mut self.__serve),
 
                     _ => panic!(
                         "Invalid reaction ID: {} should be < {}",

--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,0 +1,1 @@
+rust.support-better-multiports

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -112,6 +112,13 @@ impl<T: Sync, K> ReactionTrigger<T> for Action<K, T> {
     }
 }
 
+#[cfg(not(feature = "no-unsafe"))]
+impl<T: Sync, K> triggers::ReactionTriggerWithRefAccess<T> for Action<K, T> {
+    fn get_value_ref(&self, now: &EventTag, _start: &Instant) -> Option<&T> {
+        self.map.get(&Reverse(*now)).map(|a| a.as_ref()).flatten()
+    }
+}
+
 impl<T: Sync> ReactionTrigger<T> for LogicalAction<T> {
     #[inline]
     fn is_present(&self, now: &EventTag, start: &Instant) -> bool {
@@ -129,6 +136,13 @@ impl<T: Sync> ReactionTrigger<T> for LogicalAction<T> {
     #[inline]
     fn use_value_ref<O>(&self, now: &EventTag, start: &Instant, action: impl FnOnce(Option<&T>) -> O) -> O {
         self.0.use_value_ref(now, start, action)
+    }
+}
+
+#[cfg(not(feature = "no-unsafe"))]
+impl<T: Sync> triggers::ReactionTriggerWithRefAccess<T> for LogicalAction<T> {
+    fn get_value_ref(&self, now: &EventTag, start: &Instant) -> Option<&T> {
+        self.0.get_value_ref(now, start)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,8 +109,8 @@ pub mod assembly;
 pub mod prelude {
     pub use crate::Offset::*;
     pub use crate::{
-        after, assert_tag_is, delay, tag, AsyncCtx, Duration, EventTag, Instant, LogicalAction, PhysicalActionRef, ReactionCtx,
-        ReadablePort, ReadablePortBank, Timer, WritablePort, WritablePortBank,
+        after, assert_tag_is, delay, tag, AsyncCtx, Duration, EventTag, Instant, LogicalAction, PhysicalActionRef, Port,
+        PortBank, ReactionCtx, Timer,
     };
 
     /// Alias for the unit type, so that it can be written without quotes in LF.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,8 +109,8 @@ pub mod assembly;
 pub mod prelude {
     pub use crate::Offset::*;
     pub use crate::{
-        after, assert_tag_is, delay, tag, AsyncCtx, Duration, EventTag, Instant, LogicalAction, PhysicalActionRef, Port,
-        PortBank, ReactionCtx, Timer,
+        after, assert_tag_is, delay, tag, AsyncCtx, Duration, EventTag, Instant, LogicalAction, Multiport, PhysicalActionRef,
+        Port, ReactionCtx, Timer,
     };
 
     /// Alias for the unit type, so that it can be written without quotes in LF.

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -367,6 +367,13 @@ impl<T: Sync> PortBank<T> {
         self.iter().enumerate().filter(|&(_, p)| p.is_present_now())
     }
 
+    /// Iterate over only those ports in the bank that are set.
+    /// The returned ports are not necessarily contiguous. See
+    /// [enumerate_set] to get access to their index.
+    pub fn iterate_set(&self) -> impl Iterator<Item = &Port<T>> {
+        self.iter().filter(|&p| p.is_present_now())
+    }
+
     /// Iterate over only those ports in the bank that are set,
     /// yielding a tuple with their index in the bank and a copy of the value.
     pub fn enumerate_values(&self, _ctx: &ReactionCtx) -> impl Iterator<Item = (usize, T)> + '_

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -130,6 +130,15 @@ impl<'a, T: Sync> IntoIterator for &'a mut PortBank<T> {
     }
 }
 
+impl<'a, T: Sync> IntoIterator for &'a PortBank<T> {
+    type Item = &'a Port<T>;
+    type IntoIter = std::slice::Iter<'a, Port<T>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.ports.iter()
+    }
+}
+
 impl<T: Sync> Index<usize> for PortBank<T> {
     type Output = Port<T>;
 
@@ -171,6 +180,10 @@ impl<'a, T: Sync> ReadablePortBank<'a, T> {
     pub fn get(&self, i: usize) -> ReadablePort<T> {
         ReadablePort(&self.0.ports[i])
     }
+
+    pub fn iter(&self) -> impl Iterator<Item=ReadablePort<'_, T>> {
+        self.into_iter()
+    }
 }
 
 impl<'a, T: Sync> IntoIterator for ReadablePortBank<'a, T> {
@@ -179,6 +192,15 @@ impl<'a, T: Sync> IntoIterator for ReadablePortBank<'a, T> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.ports.iter().map(ReadablePort)
+    }
+}
+
+impl<'a, T: Sync> IntoIterator for &'a ReadablePortBank<'_, T> {
+    type Item = ReadablePort<'a, T>;
+    type IntoIter = std::iter::Map<std::slice::Iter<'a, Port<T>>, fn(&'a Port<T>) -> ReadablePort<'a, T>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        (&self.0).into_iter().map(ReadablePort)
     }
 }
 

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -247,6 +247,13 @@ impl<T: Sync> ReactionTrigger<T> for Port<T> {
     }
 }
 
+#[cfg(not(feature = "no-unsafe"))]
+impl<T: Sync> crate::triggers::ReactionTriggerWithRefAccess<T> for Port<T> {
+    fn get_value_ref(&self, _now: &EventTag, _start: &Instant) -> Option<&T> {
+        self.get_ref()
+    }
+}
+
 impl<T: Sync> TriggerLike for Port<T> {
     fn get_id(&self) -> TriggerId {
         self.id

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -220,6 +220,27 @@ impl<T: Sync> ReadablePortBank<T> {
     }
 }
 
+impl<T:Sync> Index<usize> for ReadablePortBank<T> {
+    type Output = ReadablePort<T>;
+
+    /// Allows using square brackets to access individual ports.
+    ///
+    /// ```no_run
+    /// # use reactor_rt::prelude::*;
+    /// let bank: &ReadablePortBank<u32> = unimplemented!();
+    /// let port0: &ReadablePort<u32> = &bank[0];
+    /// ```
+    ///
+    /// ```no_run
+    /// # use reactor_rt::prelude::*;
+    /// let bank: &mut WritablePortBank<u32> = unimplemented!();
+    /// let port0: &mut WritablePort<u32> = &mut bank[0];
+    /// ```
+    fn index(&self, index: usize) -> &Self::Output {
+        self.0.ports[index].as_readable()
+    }
+}
+
 impl<'a, T: Sync> IntoIterator for &'a ReadablePortBank<T> {
     type Item = &'a ReadablePort<T>;
     type IntoIter = std::iter::Map<std::slice::Iter<'a, Port<T>>, fn(&'a Port<T>) -> Self::Item>;

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -221,8 +221,8 @@ impl<T: Sync> ReactionTrigger<T> for Port<T> {
 
     #[inline]
     fn get_value(&self, _now: &EventTag, _start: &Instant) -> Option<T>
-        where
-            T: Copy,
+    where
+        T: Copy,
     {
         self.get()
     }
@@ -232,7 +232,6 @@ impl<T: Sync> ReactionTrigger<T> for Port<T> {
         self.use_ref(|opt| action(opt.as_ref()))
     }
 }
-
 
 impl<T: Sync> TriggerLike for Port<T> {
     fn get_id(&self) -> TriggerId {
@@ -323,7 +322,6 @@ impl<T: Sync> Default for PortCell<T> {
     }
 }
 
-
 /// A port bank is a vector of independent ports (its _channels_)
 /// Port banks have special Lingua Franca syntax.
 pub struct PortBank<T: Sync> {
@@ -332,7 +330,6 @@ pub struct PortBank<T: Sync> {
 }
 
 impl<T: Sync> PortBank<T> {
-
     /// Create a bank from the given vector of ports.
     #[inline(always)]
     pub(crate) fn new(ports: Vec<Port<T>>, id: TriggerId) -> Self {
@@ -373,8 +370,8 @@ impl<T: Sync> PortBank<T> {
     /// Iterate over only those ports in the bank that are set,
     /// yielding a tuple with their index in the bank and a copy of the value.
     pub fn enumerate_values(&self, _ctx: &ReactionCtx) -> impl Iterator<Item = (usize, T)> + '_
-        where
-            T: Copy,
+    where
+        T: Copy,
     {
         // note: the impl doesn't need the context, it's still there for forward compatibility
         self.enumerate_set().map(|(i, p)| p.use_ref(|value| (i, value.unwrap())))

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -343,59 +343,59 @@ impl<T: Sync> Default for PortCell<T> {
     }
 }
 
-/// A port bank is a vector of independent ports (its _channels_)
-/// Port banks have special Lingua Franca syntax.
-pub struct PortBank<T: Sync> {
+/// A multiport is a vector of independent ports (its _channels_)
+/// Multiports have special Lingua Franca syntax, similar to reactor banks.
+pub struct Multiport<T: Sync> {
     ports: Vec<Port<T>>,
     id: TriggerId,
 }
 
-impl<T: Sync> PortBank<T> {
-    /// Create a bank from the given vector of ports.
+impl<T: Sync> Multiport<T> {
+    /// Create a multiport from the given vector of ports.
     #[inline(always)]
     pub(crate) fn new(ports: Vec<Port<T>>, id: TriggerId) -> Self {
         Self { ports, id }
     }
 
-    /// Returns the length of the bank
+    /// Returns the number of channels.
     #[inline(always)]
     pub fn len(&self) -> usize {
         self.ports.len()
     }
 
-    /// Returns true if the bank is empty.
+    /// Returns true if this multiport is empty.
     #[inline(always)]
     pub fn is_empty(&self) -> bool {
         self.ports.is_empty()
     }
 
-    /// Iterate over the bank and return mutable references to individual ports.
+    /// Iterate over the multiport and return mutable references to individual channels.
     #[inline(always)]
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Port<T>> {
         self.ports.iter_mut()
     }
 
-    /// Iterate over the ports of this bank. Returns read-only
+    /// Iterate over the channels of this multiport. Returns read-only
     /// references to individual ports.
     #[inline(always)]
     pub fn iter(&self) -> impl Iterator<Item = &Port<T>> {
         self.into_iter()
     }
 
-    /// Iterate over only those ports in the bank that are set.
-    /// Returns a tuple with their index in the bank (not necessarily contiguous).
+    /// Iterate over only those channels that are set (have a value).
+    /// Returns a tuple with their index (not necessarily contiguous).
     pub fn enumerate_set(&self) -> impl Iterator<Item = (usize, &Port<T>)> {
         self.iter().enumerate().filter(|&(_, p)| p.is_present_now())
     }
 
-    /// Iterate over only those ports in the bank that are set.
+    /// Iterate over only those channels that are set (have a value).
     /// The returned ports are not necessarily contiguous. See
     /// [Self::enumerate_set] to get access to their index.
     pub fn iterate_set(&self) -> impl Iterator<Item = &Port<T>> {
         self.iter().filter(|&p| p.is_present_now())
     }
 
-    /// Iterate over only those ports in the bank that are set,
+    /// Iterate over only those channels that are set (have a value),
     /// and return a copy of the value.
     /// The returned ports are not necessarily contiguous. See
     /// [Self::enumerate_values] to get access to their index.
@@ -406,7 +406,7 @@ impl<T: Sync> PortBank<T> {
         self.iter().filter_map(|p| p.get())
     }
 
-    /// Iterate over only those ports in the bank that are set,
+    /// Iterate over only those ports that are set (have a value),
     /// and return a reference to the value.
     /// The returned ports are not necessarily contiguous. See
     /// [Self::enumerate_values] to get access to their index.
@@ -415,7 +415,7 @@ impl<T: Sync> PortBank<T> {
         self.iter().filter_map(|p| p.get_ref())
     }
 
-    /// Iterate over only those ports in the bank that are set,
+    /// Iterate over only those channels that are set (have a value),
     /// yielding a tuple with their index in the bank and a copy of the value.
     pub fn enumerate_values(&self) -> impl Iterator<Item = (usize, T)> + '_
     where
@@ -424,7 +424,7 @@ impl<T: Sync> PortBank<T> {
         self.iter().enumerate().filter_map(|(i, p)| p.get().map(|v| (i, v)))
     }
 
-    /// Iterate over only those ports in the bank that are set,
+    /// Iterate over only those channels that are set (have a value),
     /// yielding a tuple with their index in the bank and a reference to the value.
     #[cfg(not(feature = "no-unsafe"))]
     pub fn enumerate_values_ref(&self) -> impl Iterator<Item = (usize, &T)> + '_ {
@@ -432,13 +432,13 @@ impl<T: Sync> PortBank<T> {
     }
 }
 
-impl<T: Sync> TriggerLike for PortBank<T> {
+impl<T: Sync> TriggerLike for Multiport<T> {
     fn get_id(&self) -> TriggerId {
         self.id
     }
 }
 
-impl<'a, T: Sync> IntoIterator for &'a mut PortBank<T> {
+impl<'a, T: Sync> IntoIterator for &'a mut Multiport<T> {
     type Item = &'a mut Port<T>;
     type IntoIter = std::slice::IterMut<'a, Port<T>>;
 
@@ -447,7 +447,7 @@ impl<'a, T: Sync> IntoIterator for &'a mut PortBank<T> {
     }
 }
 
-impl<'a, T: Sync> IntoIterator for &'a PortBank<T> {
+impl<'a, T: Sync> IntoIterator for &'a Multiport<T> {
     type Item = &'a Port<T>;
     type IntoIter = std::slice::Iter<'a, Port<T>>;
 
@@ -456,7 +456,7 @@ impl<'a, T: Sync> IntoIterator for &'a PortBank<T> {
     }
 }
 
-impl<T: Sync> Index<usize> for PortBank<T> {
+impl<T: Sync> Index<usize> for Multiport<T> {
     type Output = Port<T>;
 
     fn index(&self, index: usize) -> &Self::Output {
@@ -464,7 +464,7 @@ impl<T: Sync> Index<usize> for PortBank<T> {
     }
 }
 
-impl<T: Sync> IndexMut<usize> for PortBank<T> {
+impl<T: Sync> IndexMut<usize> for Multiport<T> {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.ports[index]
     }

--- a/src/scheduler/assembly_impl.rs
+++ b/src/scheduler/assembly_impl.rs
@@ -320,16 +320,19 @@ pub struct DependencyDeclarator<'a, 'x, S: ReactorInitializer> {
 }
 
 impl<S: ReactorInitializer> DependencyDeclarator<'_, '_, S> {
+    #[inline]
     pub fn declare_triggers(&mut self, trigger: TriggerId, reaction: GlobalReactionId) -> AssemblyResult<()> {
         self.graph().triggers_reaction(trigger, reaction);
         Ok(())
     }
 
+    #[inline]
     pub fn effects_port<T: Sync>(&mut self, reaction: GlobalReactionId, port: &Port<T>) -> AssemblyResult<()> {
         self.effects_instantaneous(reaction, port.get_id())
     }
 
-    pub fn effects_bank<T: Sync>(&mut self, reaction: GlobalReactionId, port: &PortBank<T>) -> AssemblyResult<()> {
+    #[inline]
+    pub fn effects_multiport<T: Sync>(&mut self, reaction: GlobalReactionId, port: &Multiport<T>) -> AssemblyResult<()> {
         self.effects_instantaneous(reaction, port.get_id())
     }
 
@@ -338,11 +341,13 @@ impl<S: ReactorInitializer> DependencyDeclarator<'_, '_, S> {
         self.effects_instantaneous(reaction, timer.get_id())
     }
 
+    #[inline]
     fn effects_instantaneous(&mut self, reaction: GlobalReactionId, trigger: TriggerId) -> AssemblyResult<()> {
         self.graph().reaction_effects(reaction, trigger);
         Ok(())
     }
 
+    #[inline]
     pub fn declare_uses(&mut self, reaction: GlobalReactionId, trigger: TriggerId) -> AssemblyResult<()> {
         self.graph().reaction_uses(reaction, trigger);
         Ok(())
@@ -416,15 +421,15 @@ impl<S: ReactorInitializer> ComponentCreator<'_, '_, S> {
         Port::new(id, kind)
     }
 
-    pub fn new_port_bank<T: Sync>(
+    pub fn new_multiport<T: Sync>(
         &mut self,
         lf_name: &'static str,
         kind: PortKind,
         len: usize,
-    ) -> Result<PortBank<T>, AssemblyError> {
+    ) -> Result<Multiport<T>, AssemblyError> {
         let bank_id = self.next_comp_id(Cow::Borrowed(lf_name));
         self.graph().record_port_bank(bank_id, len)?;
-        Ok(PortBank::new(
+        Ok(Multiport::new(
             (0..len)
                 .into_iter()
                 .map(|i| self.new_port_bank_component(lf_name, kind, bank_id, i))

--- a/src/scheduler/context.rs
+++ b/src/scheduler/context.rs
@@ -1,17 +1,16 @@
 use std::borrow::Borrow;
 use std::hash::{Hash, Hasher};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
-use crossbeam_channel::reconnectable::{Receiver, Sender, SendError};
+use crossbeam_channel::reconnectable::{Receiver, SendError, Sender};
 use crossbeam_utils::thread::{Scope, ScopedJoinHandle};
 use smallvec::SmallVec;
 
-use crate::*;
+use super::*;
 use crate::assembly::*;
 use crate::scheduler::dependencies::{DataflowInfo, ExecutableReactions, LevelIx};
-
-use super::*;
+use crate::*;
 
 /// The context in which a reaction executes. Its API
 /// allows mutating the event queue of the scheduler.
@@ -806,7 +805,7 @@ pub struct CleanupCtx {
 }
 
 impl CleanupCtx {
-    pub fn cleanup_multiport<T: Sync>(&self, port: &mut PortBank<T>) {
+    pub fn cleanup_multiport<T: Sync>(&self, port: &mut Multiport<T>) {
         // todo bound ports don't need to be cleared
         for channel in port {
             channel.clear_value()

--- a/src/scheduler/context.rs
+++ b/src/scheduler/context.rs
@@ -159,7 +159,7 @@ where
     /// ```no_run
     /// # use reactor_rt::{ReactionCtx, ReadablePort};
     /// # let ctx: &mut ReactionCtx = panic!();
-    /// # let port: &ReadablePort<'_, u32> = panic!();
+    /// # let port: &ReadablePort<u32> = panic!();
     /// if let Some(value) = ctx.get(port) {
     ///     // branch is taken if the port is set -- note, this moves `port`!
     /// }

--- a/src/scheduler/context.rs
+++ b/src/scheduler/context.rs
@@ -217,10 +217,10 @@ where
     /// schedule more reactions that should execute at the
     /// same logical time.
     #[inline]
-    pub fn set<'b, T, W>(&mut self, mut port: W, value: T)
+    pub fn set<T, W>(&mut self, mut port: W, value: T)
     where
-        T: Sync + 'b,
-        W: BorrowMut<WritablePort<'b, T>>,
+        T: Sync,
+        W: BorrowMut<WritablePort<T>>,
     {
         let port = port.borrow_mut();
 
@@ -283,10 +283,10 @@ where
     /// ```
     ///
     #[inline]
-    pub fn set_opt<'b, T, W>(&mut self, port: W, value: Option<T>)
+    pub fn set_opt<T, W>(&mut self, port: W, value: Option<T>)
     where
-        T: Sync + 'b,
-        W: BorrowMut<WritablePort<'b, T>>,
+        T: Sync,
+        W: BorrowMut<WritablePort<T>>,
     {
         if let Some(v) = value {
             self.set(port, v)

--- a/src/test/stuff_that_must_compile.rs
+++ b/src/test/stuff_that_must_compile.rs
@@ -59,19 +59,19 @@ fn actions_use_ref(ctx: &mut ReactionCtx, act: &LogicalAction<u32>) {
     assert!(ctx.use_ref(act, |v| v.is_some()));
 }
 
-fn port_get(ctx: &mut ReactionCtx, port: &ReadablePort<u32>) {
+fn port_get(ctx: &mut ReactionCtx, port: &Port<u32>) {
     assert!(ctx.get(port).is_some());
 }
 
-fn port_is_present(ctx: &mut ReactionCtx, port: &ReadablePort<u32>) {
+fn port_is_present(ctx: &mut ReactionCtx, port: &Port<u32>) {
     assert!(ctx.is_present(port));
 }
 
-fn port_set(ctx: &mut ReactionCtx, port: &mut WritablePort<u32>) {
+fn port_set(ctx: &mut ReactionCtx, port: &mut Port<u32>) {
     assert_eq!(ctx.set(port, 3), ());
 }
 
-fn readable_port_bank_iter(ctx: &mut ReactionCtx, bank: &ReadablePortBank<u32>) {
+fn readable_port_bank_iter(ctx: &mut ReactionCtx, bank: &PortBank<u32>) {
     for p in bank {
         assert!(ctx.get(p).is_some());
     }
@@ -83,8 +83,8 @@ fn readable_port_bank_iter(ctx: &mut ReactionCtx, bank: &ReadablePortBank<u32>) 
     for (i, pi) in bank.iter().enumerate() {}
 }
 
-fn writable_port_bank_index(ctx: &mut ReactionCtx, bank: &ReadablePortBank<u32>) {
-    let x: &ReadablePort<u32> = &bank[1];
+fn writable_port_bank_index(ctx: &mut ReactionCtx, bank: &PortBank<u32>) {
+    let x: &Port<u32> = &bank[1];
 }
 
 fn physical_spawn_elided(ctx: &mut ReactionCtx, mut action: PhysicalActionRef<u32>) {

--- a/src/test/stuff_that_must_compile.rs
+++ b/src/test/stuff_that_must_compile.rs
@@ -59,6 +59,10 @@ fn port_get(ctx: &mut ReactionCtx, port: &ReadablePort<u32>) {
     assert!(ctx.get(port).is_some());
 }
 
+fn port_is_present(ctx: &mut ReactionCtx, port: &ReadablePort<u32>) {
+    assert!(ctx.is_present(port));
+}
+
 fn port_set(ctx: &mut ReactionCtx, port: &mut WritablePort<u32>) {
     assert_eq!(ctx.set(port, 3), ());
 }

--- a/src/test/stuff_that_must_compile.rs
+++ b/src/test/stuff_that_must_compile.rs
@@ -29,7 +29,10 @@
 
 use crate::assembly::{AssemblyCtx, ReactorInitializer};
 use crate::Offset::Asap;
-use crate::{CleanupCtx, LogicalAction, PhysicalAction, PhysicalActionRef, Port, ReactionCtx, ReadablePort, ReadablePortBank, SchedulerOptions, SyncScheduler, WritablePort};
+use crate::{
+    CleanupCtx, LogicalAction, PhysicalAction, PhysicalActionRef, Port, ReactionCtx, ReadablePort, ReadablePortBank,
+    SchedulerOptions, SyncScheduler, WritablePort,
+};
 
 fn actions_get(ctx: &mut ReactionCtx, act_mut: &mut LogicalAction<u32>, act: &LogicalAction<u32>) {
     assert!(ctx.get(act_mut).is_some());
@@ -56,21 +59,20 @@ fn port_get(ctx: &mut ReactionCtx, port: &ReadablePort<u32>) {
     assert!(ctx.get(port).is_some());
 }
 
-fn port_set(ctx: &mut ReactionCtx, mut port: WritablePort<u32>) {
+fn port_set(ctx: &mut ReactionCtx, port: &mut WritablePort<u32>) {
     assert_eq!(ctx.set(port, 3), ());
 }
 
-fn readable_port_bank_iter(ctx: &mut ReactionCtx, bank: ReadablePortBank<u32>) {
-    for p in &bank {
-        assert!(ctx.get(&p).is_some());
+fn readable_port_bank_iter(ctx: &mut ReactionCtx, bank: &ReadablePortBank<u32>) {
+    for p in bank {
+        assert!(ctx.get(p).is_some());
     }
-    for p in &bank { // should be ok to do it twice bc not moved
-        assert!(ctx.get(&p).is_some());
+    for p in bank {
+        // should be ok to do it twice bc not moved
+        assert!(ctx.get(p).is_some());
     }
 
-    for (i, pi) in bank.iter().enumerate() {
-
-    }
+    for (i, pi) in bank.iter().enumerate() {}
 }
 
 fn physical_spawn_elided(ctx: &mut ReactionCtx, mut action: PhysicalActionRef<u32>) {

--- a/src/test/stuff_that_must_compile.rs
+++ b/src/test/stuff_that_must_compile.rs
@@ -83,6 +83,10 @@ fn readable_port_bank_iter(ctx: &mut ReactionCtx, bank: &PortBank<u32>) {
     for (i, pi) in bank.iter().enumerate() {}
 }
 
+fn readable_port_bank_iter2(ctx: &mut ReactionCtx, bank: &PortBank<u32>) {
+    let count = bank.iter().filter(|&p| ctx.is_present(p)).count();
+}
+
 fn writable_port_bank_index(ctx: &mut ReactionCtx, bank: &PortBank<u32>) {
     let x: &Port<u32> = &bank[1];
 }

--- a/src/test/stuff_that_must_compile.rs
+++ b/src/test/stuff_that_must_compile.rs
@@ -28,8 +28,8 @@
 #![allow(unused)]
 
 use crate::assembly::{AssemblyCtx, ReactorInitializer};
-use crate::{CleanupCtx, Port};
 use crate::prelude::*;
+use crate::{CleanupCtx, Port};
 
 fn actions_get(ctx: &mut ReactionCtx, act_mut: &mut LogicalAction<u32>, act: &LogicalAction<u32>) {
     assert!(ctx.get(act_mut).is_some());

--- a/src/test/stuff_that_must_compile.rs
+++ b/src/test/stuff_that_must_compile.rs
@@ -28,11 +28,8 @@
 #![allow(unused)]
 
 use crate::assembly::{AssemblyCtx, ReactorInitializer};
-use crate::Offset::Asap;
-use crate::{
-    CleanupCtx, LogicalAction, PhysicalAction, PhysicalActionRef, Port, ReactionCtx, ReadablePort, ReadablePortBank,
-    SchedulerOptions, SyncScheduler, WritablePort,
-};
+use crate::{CleanupCtx, Port};
+use crate::prelude::*;
 
 fn actions_get(ctx: &mut ReactionCtx, act_mut: &mut LogicalAction<u32>, act: &LogicalAction<u32>) {
     assert!(ctx.get(act_mut).is_some());

--- a/src/test/stuff_that_must_compile.rs
+++ b/src/test/stuff_that_must_compile.rs
@@ -83,6 +83,10 @@ fn readable_port_bank_iter(ctx: &mut ReactionCtx, bank: &ReadablePortBank<u32>) 
     for (i, pi) in bank.iter().enumerate() {}
 }
 
+fn writable_port_bank_index(ctx: &mut ReactionCtx, bank: &ReadablePortBank<u32>) {
+    let x: &ReadablePort<u32> = &bank[1];
+}
+
 fn physical_spawn_elided(ctx: &mut ReactionCtx, mut action: PhysicalActionRef<u32>) {
     use std::thread;
 

--- a/src/test/stuff_that_must_compile.rs
+++ b/src/test/stuff_that_must_compile.rs
@@ -29,10 +29,7 @@
 
 use crate::assembly::{AssemblyCtx, ReactorInitializer};
 use crate::Offset::Asap;
-use crate::{
-    CleanupCtx, LogicalAction, PhysicalAction, PhysicalActionRef, Port, ReactionCtx, ReadablePort, SchedulerOptions,
-    SyncScheduler, WritablePort,
-};
+use crate::{CleanupCtx, LogicalAction, PhysicalAction, PhysicalActionRef, Port, ReactionCtx, ReadablePort, ReadablePortBank, SchedulerOptions, SyncScheduler, WritablePort};
 
 fn actions_get(ctx: &mut ReactionCtx, act_mut: &mut LogicalAction<u32>, act: &LogicalAction<u32>) {
     assert!(ctx.get(act_mut).is_some());
@@ -61,6 +58,19 @@ fn port_get(ctx: &mut ReactionCtx, port: &ReadablePort<u32>) {
 
 fn port_set(ctx: &mut ReactionCtx, mut port: WritablePort<u32>) {
     assert_eq!(ctx.set(port, 3), ());
+}
+
+fn readable_port_bank_iter(ctx: &mut ReactionCtx, bank: ReadablePortBank<u32>) {
+    for p in &bank {
+        assert!(ctx.get(&p).is_some());
+    }
+    for p in &bank { // should be ok to do it twice bc not moved
+        assert!(ctx.get(&p).is_some());
+    }
+
+    for (i, pi) in bank.iter().enumerate() {
+
+    }
 }
 
 fn physical_spawn_elided(ctx: &mut ReactionCtx, mut action: PhysicalActionRef<u32>) {

--- a/src/test/stuff_that_must_compile.rs
+++ b/src/test/stuff_that_must_compile.rs
@@ -71,7 +71,7 @@ fn port_set(ctx: &mut ReactionCtx, port: &mut Port<u32>) {
     assert_eq!(ctx.set(port, 3), ());
 }
 
-fn readable_port_bank_iter(ctx: &mut ReactionCtx, bank: &PortBank<u32>) {
+fn readable_port_bank_iter(ctx: &mut ReactionCtx, bank: &Multiport<u32>) {
     for p in bank {
         assert!(ctx.get(p).is_some());
     }
@@ -83,11 +83,11 @@ fn readable_port_bank_iter(ctx: &mut ReactionCtx, bank: &PortBank<u32>) {
     for (i, pi) in bank.iter().enumerate() {}
 }
 
-fn readable_port_bank_iter2(ctx: &mut ReactionCtx, bank: &PortBank<u32>) {
+fn readable_port_bank_iter2(ctx: &mut ReactionCtx, bank: &Multiport<u32>) {
     let count = bank.iter().filter(|&p| ctx.is_present(p)).count();
 }
 
-fn writable_port_bank_index(ctx: &mut ReactionCtx, bank: &PortBank<u32>) {
+fn writable_port_bank_index(ctx: &mut ReactionCtx, bank: &Multiport<u32>) {
     let x: &Port<u32> = &bank[1];
 }
 

--- a/src/triggers.rs
+++ b/src/triggers.rs
@@ -56,6 +56,18 @@ pub trait ReactionTrigger<T> {
     fn use_value_ref<O>(&self, now: &EventTag, start: &Instant, action: impl FnOnce(Option<&T>) -> O) -> O;
 }
 
+#[cfg(not(feature = "no-unsafe"))]
+pub trait ReactionTriggerWithRefAccess<T> {
+    /// Returns a reference to the value, if it is present. Whether a *value*
+    /// is present is not in general the same thing as whether *this trigger*
+    /// [Self::is_present]. See [crate::ReactionCtx::get_ref].
+    ///
+    /// This does not require the value to be Copy, however, the implementation
+    /// of this method currently may require unsafe code. The method is therefore
+    /// not offered when compiling with the `no-unsafe` feature.
+    fn get_value_ref(&self, now: &EventTag, start: &Instant) -> Option<&T>;
+}
+
 /// Something on which we can declare a trigger dependency
 /// in the dependency graph.
 #[doc(hidden)]


### PR DESCRIPTION
This removes the `Readable/Writable` variants for `PortBank` and `Port`. Now instead of injecting `ReadablePort` we inject `&Port`, and `&mut Port` for WritablePort (same for PortBank). 

Benefits:
- no more indirection to access the port (previously we were actually using double references)
- more intuitive types for the injected parameters. Since their type is not visible in the LF program I think this is very significant.
- easier access to ports through portbank: 
  - we can implement `Index` and get index-based access (`ctx.set(&bank[i], value)`)
  - we can also iterate more easily on PortBank, eg
```rust
for (i, port_i) in bank.iter().enumerate() {
   // use both index and port
}
```
- code simplification

Drawbacks:
- an `&mut Port` can be reassigned, eg if you have write access to two ports, you can swap them in memory. This seems acceptable to me, as this is already possible with other types like `&mut LogicalAction`. Doing this also pretty obviously breaks the program semantics. Previously if you wanted to do this you would have needed an unsafe `transmute` call.
- `&mut Port` can also be read from, which was not the case for `WritablePort`. I think this is acceptable as anyway, there is at most one reaction that can set a given port, and that reaction will only observe values that it has set itself.


