### PR TITLE
Remove nightly rust toolchain file

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,0 @@
-nightly


### PR DESCRIPTION
Everything works with Rust stable now, there is no reason to pin Rust Nightly any more.