### PR TITLE
Use stable toolchain for lints in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,11 +51,10 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@v2
 
-    - name: Install stable toolchain
-      uses: actions-rs/toolchain@v1
+    - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: stable
         override: true
         components: rustfmt, clippy
 


### PR DESCRIPTION
The use of the nightly toolchain causes failures in CI: https://github.com/lf-lang/reactor-rs/actions/runs/3345256641/jobs/5540551199

This is because clippy is reporting something that can only be fixed when using Rust 1.65 nightly, whereas we currently use 1.64 stable, so we can't fix these lints.

Somewhat related to #32 