### PR TITLE
chore: Bump dependencies to avoid vulnerability in smallvec

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,7 +11,7 @@ log = "0.4"
 index_vec = "0.1"
 #itertools = "0.10.1"
 #bit-set = "0.5"
-smallvec = { version = "1.6", features = ["const_generics"] }
+smallvec = { version = "1.10", features = ["const_generics"] }
 petgraph = "0.6"
 array-macro = "2.1"
 atomic_refcell = "0.1"


### PR DESCRIPTION
This bumps the `smallvec` dependency of the runtime to version `1.10` to avoid a possible security vulnerability, cf. [here](https://deps.rs/repo/github/lf-lang/reactor-rust).