### PR TITLE
Fix use of multiport as reaction source

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,4 @@ Inspect results
 ```
 $ opannotate --source | less
 ```
+


### PR DESCRIPTION
The reaction graph wasn't being properly updated, so that some reactions were put on the same level when they actually depend on one another. 

Fix https://github.com/lf-lang/lingua-franca/issues/1654