### PR TITLE
chore: Bump dependencies to avoid vulnerability in smallvec

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,7 +11,7 @@ log = "0.4"
 index_vec = "0.1"
 #itertools = "0.10.1"
 #bit-set = "0.5"
-smallvec = { version = "1.6", features = ["const_generics"] }
+smallvec = { version = "1.10", features = ["const_generics"] }
 petgraph = "0.6"
 array-macro = "2.1"
 atomic_refcell = "0.1"


### PR DESCRIPTION
Reopening this because the CI build apparently doesn't like that the branch name used in #42 contains a slash