### PR TITLE
Fixes for current Clippy version

### DIFF
--- a/runtime/src/scheduler/assembly_impl.rs
+++ b/runtime/src/scheduler/assembly_impl.rs
@@ -270,7 +270,6 @@ where
         trace!("Assembling bank {}", inst_name);
 
         let mut sub = (0..bank_width)
-            .into_iter()
             .map(|i| self.assemble_sub(inst_name, Some(i), arg_maker(i)))
             .collect::<Result<Vec<Sub>, _>>()?;
 
@@ -431,7 +430,6 @@ impl<S: ReactorInitializer> ComponentCreator<'_, '_, S> {
         self.graph().record_port_bank(bank_id, len)?;
         Ok(Multiport::new(
             (0..len)
-                .into_iter()
                 .map(|i| self.new_port_bank_component(lf_name, kind, bank_id, i))
                 .collect(),
             bank_id,

--- a/runtime/src/triggers.rs
+++ b/runtime/src/triggers.rs
@@ -117,7 +117,7 @@ impl TriggerId {
     /// Returns `Err` on overflow.
     pub(crate) fn iter_next_range(&self, len: usize) -> Result<impl Iterator<Item = Self>, ()> {
         if let Some(upper) = self.0.checked_add(1 + (len as TriggerIdImpl)) {
-            Ok(((self.0 + 1)..upper).into_iter().map(TriggerId))
+            Ok(((self.0 + 1)..upper).map(TriggerId))
         } else {
             Err(())
         }
@@ -132,7 +132,7 @@ impl TriggerId {
     }
 
     pub(crate) fn iter_range(range: &Range<TriggerId>) -> impl Iterator<Item = TriggerId> {
-        (range.start.0..range.end.0).into_iter().map(TriggerId)
+        (range.start.0..range.end.0).map(TriggerId)
     }
 }
 


### PR DESCRIPTION
CI keeps failing because of unnecessary uses of `into_iter()`.