### PR TITLE
Fix all warnings for Rust 1.84.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,24 +32,24 @@
 //!
 //! Crate-level features include:
 //! - `parallel-runtime`: use Rayon to execute reactions in parallel
-//! when possible. This is not yet the default. For some applications,
-//! where there is no data parallelism, this may harm performance
-//! (as well as pull in unneeded dependencies) and should be off.
+//!   when possible. This is not yet the default. For some applications,
+//!   where there is no data parallelism, this may harm performance
+//!   (as well as pull in unneeded dependencies) and should be off.
 //! - `wide-ids`: Enables 64-bit wide reaction ids on 64-bit
-//! architectures. This may reduce performance, but allows for
-//! 2^32 reactor instances compared to the default of 2^16,
-//! which may feel a bit tight for some applications. On machines
-//! with a pointer-width of less than 64 bits, ID types are
-//! always 32 bits. The feature also widens trigger ids to 64 bits
-//! if possible, which enables 2^64 individual trigger components
-//! (ports, actions, etc.) instead of 2^32.
+//!   architectures. This may reduce performance, but allows for
+//!   2^32 reactor instances compared to the default of 2^16,
+//!   which may feel a bit tight for some applications. On machines
+//!   with a pointer-width of less than 64 bits, ID types are
+//!   always 32 bits. The feature also widens trigger ids to 64 bits
+//!   if possible, which enables 2^64 individual trigger components
+//!   (ports, actions, etc.) instead of 2^32.
 //! - `vec-id-sets`: Change the implementation of reaction sets
-//! to be a sorted vector instead of a hash set. This has a positive
-//! performance impact, as reaction sets are typically very small.
-//! More testing is required to determine pathological cases.
-//! This is a default feature.
+//!   to be a sorted vector instead of a hash set. This has a positive
+//!   performance impact, as reaction sets are typically very small.
+//!   More testing is required to determine pathological cases.
+//!   This is a default feature.
 //! - `no-unsafe`: disable optimisations that use unsafe code in this runtime.
-//! Just provided for comparison, should probably be removed (unsafe code is fine).
+//!   Just provided for comparison, should probably be removed (unsafe code is fine).
 
 // #![deny(unused_crate_dependencies)]
 #![deny(unused_extern_crates)]
@@ -61,17 +61,15 @@
 #[macro_use]
 extern crate array_macro;
 #[cfg(test)]
-#[allow(unused)]
+#[allow(unused, unused_imports)]
 #[macro_use]
 extern crate assert_matches;
-#[macro_use]
-extern crate index_vec;
+// #[macro_use]
+// extern crate index_vec;
 #[macro_use]
 extern crate log;
 #[cfg(feature = "parallel-runtime")]
 extern crate rayon;
-#[macro_use]
-extern crate smallvec;
 #[macro_use]
 extern crate static_assertions;
 #[macro_use]

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -304,7 +304,7 @@ struct PortCell<T: Sync> {
     /// - say you have bound A -> B, then B -> C
     /// - so all three refer to the equiv class of A, whose downstream is now {B, C}
     /// - if you then try binding C -> A, then we can know
-    /// that C is in the downstream of A, indicating that there is a cycle.
+    ///   that C is in the downstream of A, indicating that there is a cycle.
     downstreams: Downstreams<T>,
 }
 

--- a/src/scheduler/assembly_impl.rs
+++ b/src/scheduler/assembly_impl.rs
@@ -119,7 +119,8 @@ where
 }
 
 /// Final result of the assembly of a reactor.
-pub struct FinishedReactor<'x, S>(AssemblyCtx<'x, S>, S)
+#[allow(unused_variables)]
+pub struct FinishedReactor<'x, S>(PhantomData<&'x mut u8>, S)
 where
     S: ReactorInitializer;
 
@@ -148,8 +149,8 @@ where
         self,
         build_reactor_tree: impl FnOnce(Self) -> AssemblyResult<AssemblyIntermediate<'x, S>>,
     ) -> AssemblyResult<FinishedReactor<'x, S>> {
-        let AssemblyIntermediate(ich, reactor) = build_reactor_tree(self)?;
-        Ok(FinishedReactor(ich, reactor))
+        let AssemblyIntermediate(_, reactor) = build_reactor_tree(self)?;
+        Ok(FinishedReactor(PhantomData, reactor))
     }
 
     /// Innermost function.
@@ -263,7 +264,7 @@ where
     ) -> AssemblyResult<AssemblyIntermediate<'x, S>>
     where
         Sub: ReactorInitializer + 'static,
-        // we can't use impl Fn(...) because we want to specify explicit type parameters in the calle
+    // we can't use impl Fn(...) because we want to specify explicit type parameters in the calle
         F: FnOnce(Self, &mut Vec<Sub>) -> AssemblyResult<AssemblyIntermediate<'x, S>>,
         A: Fn(/*bank_index:*/ usize) -> Sub::Params,
     {
@@ -367,8 +368,8 @@ impl<S: ReactorInitializer> DependencyDeclarator<'_, '_, S> {
     #[inline]
     pub fn bind_ports_zip<'a, T: Sync + 'a>(
         &mut self,
-        upstream: impl Iterator<Item = &'a mut Port<T>>,
-        downstream: impl Iterator<Item = &'a mut Port<T>>,
+        upstream: impl Iterator<Item=&'a mut Port<T>>,
+        downstream: impl Iterator<Item=&'a mut Port<T>>,
     ) -> AssemblyResult<()> {
         for (upstream, downstream) in upstream.zip(downstream) {
             self.bind_ports(upstream, downstream)?;
@@ -379,8 +380,8 @@ impl<S: ReactorInitializer> DependencyDeclarator<'_, '_, S> {
     #[inline]
     pub fn bind_ports_iterated<'a, T: Sync + 'a>(
         &mut self,
-        upstream: impl Iterator<Item = &'a mut Port<T>>,
-        mut downstream: impl Iterator<Item = &'a mut Port<T>>,
+        upstream: impl Iterator<Item=&'a mut Port<T>>,
+        mut downstream: impl Iterator<Item=&'a mut Port<T>>,
     ) -> AssemblyResult<()> {
         let mut upstream = upstream.collect::<Vec<_>>();
         assert!(!upstream.is_empty(), "Empty upstream!");

--- a/src/scheduler/assembly_impl.rs
+++ b/src/scheduler/assembly_impl.rs
@@ -264,7 +264,7 @@ where
     ) -> AssemblyResult<AssemblyIntermediate<'x, S>>
     where
         Sub: ReactorInitializer + 'static,
-    // we can't use impl Fn(...) because we want to specify explicit type parameters in the calle
+        // we can't use impl Fn(...) because we want to specify explicit type parameters in the calle
         F: FnOnce(Self, &mut Vec<Sub>) -> AssemblyResult<AssemblyIntermediate<'x, S>>,
         A: Fn(/*bank_index:*/ usize) -> Sub::Params,
     {
@@ -368,8 +368,8 @@ impl<S: ReactorInitializer> DependencyDeclarator<'_, '_, S> {
     #[inline]
     pub fn bind_ports_zip<'a, T: Sync + 'a>(
         &mut self,
-        upstream: impl Iterator<Item=&'a mut Port<T>>,
-        downstream: impl Iterator<Item=&'a mut Port<T>>,
+        upstream: impl Iterator<Item = &'a mut Port<T>>,
+        downstream: impl Iterator<Item = &'a mut Port<T>>,
     ) -> AssemblyResult<()> {
         for (upstream, downstream) in upstream.zip(downstream) {
             self.bind_ports(upstream, downstream)?;
@@ -380,8 +380,8 @@ impl<S: ReactorInitializer> DependencyDeclarator<'_, '_, S> {
     #[inline]
     pub fn bind_ports_iterated<'a, T: Sync + 'a>(
         &mut self,
-        upstream: impl Iterator<Item=&'a mut Port<T>>,
-        mut downstream: impl Iterator<Item=&'a mut Port<T>>,
+        upstream: impl Iterator<Item = &'a mut Port<T>>,
+        mut downstream: impl Iterator<Item = &'a mut Port<T>>,
     ) -> AssemblyResult<()> {
         let mut upstream = upstream.collect::<Vec<_>>();
         assert!(!upstream.is_empty(), "Empty upstream!");

--- a/src/scheduler/context.rs
+++ b/src/scheduler/context.rs
@@ -16,7 +16,7 @@ use crate::*;
 /// allows mutating the event queue of the scheduler.
 /// Only the interactions declared at assembly time
 /// are allowed.
-
+///
 // Implementation details:
 // ReactionCtx is an API built around a ReactionWave. A single
 // ReactionCtx may be used for multiple ReactionWaves, but

--- a/src/scheduler/dependencies.rs
+++ b/src/scheduler/dependencies.rs
@@ -109,7 +109,7 @@ pub(super) struct DepGraph {
     /// - port/action -> reaction: the port/action triggers the reaction
     /// - port -> port: a binding of a port to another
     /// - reaction n -> reaction m: means n has higher priority
-    /// than m, only filled in for reactions of the same reactor.
+    ///   than m, only filled in for reactions of the same reactor.
     dataflow: DepGraphImpl,
 
     /// Maps global IDs back to graph indices.
@@ -342,7 +342,7 @@ enum EdgeWeight {
     /// if they're labeled `Default`, they're trigger dependencies,
     /// otherwise use dependencies.
     Default,
-    ///
+    /// See [Default].
     Use,
 }
 
@@ -604,7 +604,7 @@ impl<'x> ExecutableReactions<'x> {
     }
 
     #[inline]
-    pub fn next_batch<'a>(&'a self, min_level_exclusive: KeyRef<&LevelIx>) -> Option<(KeyRef<&'a LevelIx>, &Level)> {
+    pub fn next_batch<'a>(&'a self, min_level_exclusive: KeyRef<&LevelIx>) -> Option<(KeyRef<&'a LevelIx>, &'a Level)> {
         self.levels
             .next_mapping(min_level_exclusive)
             .map(|(ix, cow)| (ix, cow.as_ref()))

--- a/src/scheduler/scheduler_impl.rs
+++ b/src/scheduler/scheduler_impl.rs
@@ -169,6 +169,7 @@ impl<'x> SyncScheduler<'x> {
                 /// internals are not copied).
                 /// So long as the framework entirely controls the lifetime
                 /// of SyncScheduler instances, this is enforceable.
+                #[allow(non_local_definitions)]
                 unsafe impl Send for SyncScheduler<'_> {}
 
                 // install makes calls to parallel iterators use that thread pool

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -64,7 +64,6 @@ pub(crate) fn do_write<X>(
     write!(f, "{}", suffix)
 }
 
-
 /// Creates a [Duration] value using the same syntax as in LF.
 ///
 /// ```
@@ -157,7 +156,6 @@ macro_rules! tag {
         $crate::EventTag::offset($crate::delay!($amount $unit), $microstep)
     };
 }
-
 
 /// Convenient macro to assert equality of the current tag.
 /// This is just shorthand for using `assert_eq!` with the

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -64,19 +64,6 @@ pub(crate) fn do_write<X>(
     write!(f, "{}", suffix)
 }
 
-/// Shorthand for using [After](crate::Offset::After) together with [delay].
-///
-/// ```
-/// use std::time::Duration;
-/// use reactor_rt::{after, Offset::After};
-///
-/// assert_eq!(after!(10 ns), After(Duration::from_nanos(10)));
-/// assert_eq!(after!(2 min), After(Duration::from_secs(120)));
-/// ```
-#[macro_export]
-macro_rules! after {
-    ($amount:tt $unit:tt) => { $crate::Offset::After($crate::delay!($amount $unit)) }
-}
 
 /// Creates a [Duration] value using the same syntax as in LF.
 ///
@@ -133,6 +120,45 @@ macro_rules! delay {
     ($amount:tt $i:ident) => { compile_error!(concat!("Unknown time unit `", stringify!($i), "`")) };
 }
 
+/// Shorthand for using [After](crate::Offset::After) together with [delay].
+///
+/// ```
+/// use std::time::Duration;
+/// use reactor_rt::{after, Offset::After};
+///
+/// assert_eq!(after!(10 ns), After(Duration::from_nanos(10)));
+/// assert_eq!(after!(2 min), After(Duration::from_secs(120)));
+/// ```
+#[macro_export]
+macro_rules! after {
+    ($amount:tt $unit:tt) => { $crate::Offset::After($crate::delay!($amount $unit)) }
+}
+
+/// Convenient macro to [create a tag](crate::EventTag).
+/// This is just a shorthand for using the constructor together
+/// with the syntax of [delay].
+///
+/// ```no_run
+/// use reactor_rt::{tag, delay};
+///
+/// tag!(T0 + 20 ms);
+/// tag!(T0 + 60 ms);
+/// tag!(T0); // the origin tag
+/// // with a microstep:
+/// tag!(T0, 1);
+/// tag!(T0 + 3 sec, 1);
+/// ```
+#[macro_export]
+macro_rules! tag {
+    (T0)                          => {$crate::EventTag::ORIGIN};
+    (T0, $microstep:expr)         => {tag!(T0 + 0 sec, $microstep)};
+    (T0 + $amount:tt $unit:ident) => {tag!(T0 + $amount $unit, 0)};
+    (T0 + $amount:tt $unit:ident, $microstep:expr) => {
+        $crate::EventTag::offset($crate::delay!($amount $unit), $microstep)
+    };
+}
+
+
 /// Convenient macro to assert equality of the current tag.
 /// This is just shorthand for using `assert_eq!` with the
 /// syntax of [tag].
@@ -161,30 +187,6 @@ macro_rules! assert_tag_is {
             $crate::tag!(T0 + $amount $unit, $microstep),
             $ctx.get_tag()
         )
-    };
-}
-
-/// Convenient macro to [create a tag](crate::EventTag).
-/// This is just a shorthand for using the constructor together
-/// with the syntax of [delay].
-///
-/// ```no_run
-/// use reactor_rt::{tag, delay};
-///
-/// tag!(T0 + 20 ms);
-/// tag!(T0 + 60 ms);
-/// tag!(T0); // the origin tag
-/// // with a microstep:
-/// tag!(T0, 1);
-/// tag!(T0 + 3 sec, 1);
-/// ```
-#[macro_export]
-macro_rules! tag {
-    (T0)                          => {$crate::EventTag::ORIGIN};
-    (T0, $microstep:expr)         => {tag!(T0 + 0 sec, $microstep)};
-    (T0 + $amount:tt $unit:ident) => {tag!(T0 + $amount $unit, 0)};
-    (T0 + $amount:tt $unit:ident, $microstep:expr) => {
-        $crate::EventTag::offset($crate::delay!($amount $unit), $microstep)
     };
 }
 


### PR DESCRIPTION
Fix new clippy warnings present in newer clippy versions. See #50 