### PR TITLE
Disable benchmark tests, which are no longer working

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,8 +24,9 @@ jobs:
       run: cargo build
     - name: Run tests
       run: cargo test --all-features
-    - name: Run benchmark tests
-      run: cargo test --benches --all-features
+    # These started failing on 2025-06-08.
+    #- name: Run benchmark tests
+    #  run: cargo test --benches --all-features
     # documentation
     - name: Build documentation
       run: cargo doc --frozen --no-deps


### PR DESCRIPTION
As indicated in this PR: https://github.com/lf-lang/benchmarks-lingua-franca/pull/70
the Rust benchmark tests no longer work, giving a compile error.
These are blocking all progress in lingua-franca.
This PR disables those tests in this repo.